### PR TITLE
Use 'toStringTag' for checking 'types'

### DIFF
--- a/Demo/index.js
+++ b/Demo/index.js
@@ -11,16 +11,6 @@ const type = Symbol.type;
 const printHTML = html => html.replace(/</g, `&lt;`);
 printExamples();
 
-function SomeCTOR(something) {
-  this.something = something;
-}
-
-function someProxy() {
-  return new Proxy(new String(`hello`), {
-    get(obj, key) { return key === 'world' ? ((obj += " world"), obj) : obj[key] }
-  });
-}
-
 document.querySelectorAll(`code.block`)
   .forEach(block => {
     block.classList.remove(`block`);
@@ -60,17 +50,7 @@ function getHeader() {
     const [tru, flse, zero, not_a_nr, nil, undef, div, proxyEx] =
       [true, false, 0, +("NaN"), null, undefined, 
        document.createElement("div"), someProxy()];
-    const SharedArrayBufferTrial = maybe({
-      trial: _ => new SharedArrayBuffer(16)?.[type],
-      whenError: _ => "Tried &lt;code>new SharedArrayBuffer(16)?.[type]&lt;/code>\\
-        &lt;br>Failed=> &lt;code>SharedArrayBuffer&lt;/code> not available,\\
-        security conditions probably not met" });
-    const IteratorTrial = maybe({
-      trial: _ => Iterator.from([1,2,3]?.Type,
-      whenError: _ => 
-          "Tried &lt;code>Iterator.from([1,2,3])&lt;/code>\\
-          &lt;br>Failed => Iterator is experimental and not available in all browsers" });
-      
+    
     // a constructor
     function SomeCTOR(something) {
       this.something = something;
@@ -87,17 +67,17 @@ function codeExamples() {
   const [tru, flse, zero, not_a_nr, nil, undef, div, proxyEx] =
     [true, false, 0, +("NaN"), null, undefined, document.createElement(`div`), someProxy()];
   div.textContent = `I am div`;
-  const SharedArrayBufferTrial = maybe({
-    trial: _ => new SharedArrayBuffer(16)?.[type],
-    whenError: _ => `Tried <code>new SharedArrayBuffer(16)?.[type]</code>
-      <div>Failed => <code>SharedArrayBuffer</code> not available, security conditions probably not met</div>
-      <div>See <a target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer"
-      >MDN</a></div>`});
-  const IteratorTrial = maybe({
-    trial: _ => `<code>Iterator.from([1,2,3]?.[type]</code> ${Iterator.from([1,2,3])?.[type]}`,
-    whenError: _ => `Tried <code>Iterator.from([1,2,3])?.[type]</code> 
-      <br>Failed => Iterator is experimental and not available in all browsers`
-  });
+  
+  function SomeCTOR(something) {
+    this.something = something;
+  }
+  
+  function someProxy() {
+    return new Proxy(new String(`hello`), {
+      get(obj, key) { return key === 'world' ? ((obj += " world"), obj) : obj[key] }
+    });
+  }
+  
   return [
     getHeader(),
     t => `<div class="normal"><b>The IS function</b></div>`,
@@ -111,7 +91,7 @@ function codeExamples() {
     _ => IS(flse),
     _ => IS({} + [], String /* ES peculiarity */),
     _ => IS(true + false, Number /* ES peculiarity */),
-    
+
     t => `<div class="normal"><b>The Object symbolic extension</b></div>`,
     _ => [][type],
     _ => [][is](Map),
@@ -121,13 +101,13 @@ function codeExamples() {
     _ => `Hello World`[is](String),
     _ => `Hello World`[is](Object),
     _ => new String(`Hello World`)[is](Object),
-    
+
     t => `<div class="normal"><b>Note</b>: one can also use <code>Symbol.type/Symbol.is</code> directly</div>`,
     _ => [][Symbol.type],
     _ => [][Symbol.is](Map),
     _ => ({})[Symbol.is](Array),
     _ => [][Symbol.is](Object /* up the prototoype chain */),
-    
+
     t => `<div class="normal"><b>The <i>static</i> Object symbolic extension</b></div>`,
     _ => Object[type](`Hello`),
     _ => Object[is]([], Map),
@@ -136,7 +116,7 @@ function codeExamples() {
     _ => Object[Symbol.is](not_a_nr, NaN),
     _ => Object[is](not_a_nr, NaN, Number),
     _ => Object[is](`Hello world`, NaN, Number, String),
-    
+
     t => `<div class="normal"><b>The wrapper <code>$Wrap</code></b></div>`,
     _ => $Wrap([])[type],
     _ => $Wrap([]).type,
@@ -150,7 +130,7 @@ function codeExamples() {
            can <i>only</i> be checked using the wrapper</div>`,
     _ => null?.[type] ?? $Wrap(null).type,
     _ => undefined?.[is](undefined) ?? $Wrap(undefined).is(undefined),
-    
+
     t => `<div class="normal"><b>The <code>maybe</code> function</b></div>`,
     _ => maybe({trial() {return {};}})[is](Object),
     _ => maybe({trial: () => $Wrap(null)}).is(null),
@@ -162,7 +142,7 @@ function codeExamples() {
     _ => maybe({trial: () => {throw new Error(`error!`);}, whenError() {return `no!`}})[is](String),
     _ => maybe({trial: () => {throw new TypeError(`no!`);}, whenError(err) {return err.name; }}),
     _ => maybe({trial: () => {throw new TypeError(`no!`);}, whenError(err) {return err.name; }})[is](String),
-    
+
     t => `<div class="normal">
             <b>Proxy</b><br>
             A <code>Proxy</code> instance has no prototype,
@@ -183,7 +163,7 @@ function codeExamples() {
     _ => proxyEx[type],
     _ => proxyEx[is](Proxy),
     _ => proxyEx[is](String),
-    
+
     // TODO
     t => xProxy.native(),
     t => `<div class="normal">When we reset <code>Proxy</code>
@@ -193,13 +173,13 @@ function codeExamples() {
     _ => new Proxy(new String(), {})[type],
     _ => new Proxy(new Date(), {})[type],
     _ => new Proxy(new Date(), {})[is](Date),
-    
+
     t => `<div class="normal"><b>Note</b>: <code>proxyEx</code> was assigned with the modified
            <code>Proxy</code> constructor, so:</div>`,
     _ => proxyEx[type],
     _ => proxyEx[is](Proxy),
     _ => proxyEx[is](String),
-    
+
     t => `<div class="normal"><b>null, undefined, true, false</b>
           <br><b>Note</b>: <code>null</code> and <code>undefined</code>
           must always be wrapped. </div>`,
@@ -217,7 +197,7 @@ function codeExamples() {
     _ => undef?.[type] ?? $Wrap(undefined)[type],
     _ => undef?.[is](undefined) ?? $Wrap(undef)[is](undefined),
     _ => undef?.[is](null, NaN) ?? $Wrap(undef)[is](null, NaN),
-    
+
     t => `<div class="normal"><b>'Nothingness'</b> (<code>isNothing</code>)<br>
           <code>isNothing</code> is a special
           function imported from the module.
@@ -241,7 +221,7 @@ function codeExamples() {
     _ => isNothing(new Date(`error!`).getTime(), true),
     _ => isNothing(new Date()),
     _ => isNothing(new Date(), true),
-    
+
     t => `<div class="normal"><b>0 (zero)</b></div>`,
     _ => zero[type],
     _ => zero[is](Boolean /* should be false */),
@@ -249,7 +229,7 @@ function codeExamples() {
     _ => zero[is](Object /* literal not Object */),
     _ => new Number(zero)[is](Number),
     _ => new Number(zero)[is](Object /*<br>&nbsp;&nbsp;Up the prototype chain, Number instance is also Object */),
-    
+
     t => `<div class="normal"><b>NaN</b></div>`,
     _ => typeof not_a_nr,
     _ => not_a_nr[is](Number /* by design we DON'T consider NaN to be Number */),
@@ -260,7 +240,7 @@ function codeExamples() {
     _ => typeof new Number(not_a_nr),
     _ => new Number(not_a_nr)[type],
     _ => new Number(not_a_nr)[is](NaN),
-    
+
     t => `<div class="normal"><b>Special cases</b>
             (<code>IS(input, {isTypes: [...types], notTypes: [...types]|defaultValue: any})</code>)
             <div>When the second parameter (or the first, using the Object symbol extension or <code>$Wrap</code>)
@@ -283,19 +263,19 @@ function codeExamples() {
     _ => IS(div, {isTypes: HTMLDivElement, notTypes: HTMLUnknownElement}),
     _ => IS(div, {isTypes: HTMLUListElement, defaultValue: printHTML(div.outerHTML)}),
     _ => IS(div, {isTypes: [undefined, null, NaN], defaultValue: printHTML(div.outerHTML)}),
-    
+
     t => xProxy.custom(),
-    t => `<div class="normal">* Rewritten <code>Proxy</code> constructor (<code>xProxy.custom()</code>)</div>`,
+    t => `<div class="normal"><b>*</b> Rewritten <code>Proxy</code> constructor (<code>xProxy.custom()</code>)</div>`,
     _ => new Proxy(new Date(), {})[type],
     _ => new Proxy(new Date(), {})[is]({isTypes: Proxy, notTypes: Date}),
     _ => new Proxy(new Date(), {})[is]({isTypes: Date, notTypes: Proxy}),
-    
+
     t => xProxy.native(),
-    t => `<div class="normal">* Native <code>Proxy</code> constructor (<code>xProxy.native()</code>)</div>`,
+    t => `<div class="normal"><b>*</b> Native <code>Proxy</code> constructor (<code>xProxy.native()</code>)</div>`,
     _ => new Proxy(new Date(), {})[type],
     _ => new Proxy(new Date(), {})[is]({isTypes: Proxy, notTypes: Date}),
     _ => new Proxy(new Date(), {})[is]({isTypes: Date, notTypes: Proxy}),
-    
+
     t => `<div class="normal"><b>More examples</b></div>`,
     _ => /[a-z]/[type],
     _ => /[a-z]/[is](RegExp),
@@ -304,28 +284,67 @@ function codeExamples() {
     _ => new SomeCTOR("yada")[type],
     _ => new SomeCTOR("yada")[is](SomeCTOR),
     _ => new SomeCTOR("yada")[is](Object /* up the prototype chain */),
-    _ => Symbol(`anything`)[type],
-    _ => div[type],
+    _ => Symbol(`me`)[is](Symbol),
     _ => div[is](Node),
     _ => div[is](HTMLElement),
     _ => div[is](HTMLDivElement),
     _ => div[is](HTMLUListElement),
     _ => div[is](HTMLUListElement, HTMLAreaElement, Node),
+    
+    t => `<div class="normal"><b>toStringTag</b>:
+            use <code>Symbol.toStringTag</code> for reporting/checking 'types'.
+          <div>A number of ES20xx Objects contain the 'well known Symbol'
+            <code>Symbol.toStringTag</code> in their prototype. Such objects
+            use that Symbol for their string representation (<code>toString</code>).
+            When available <code>IS(input)</code> or <code>[type]</code> reports
+            that as the 'type' of the input between square brackets.
+            <br>Such 'types' are <i>not always available</i> as known constructors in
+            the (global) namespace (as <code>HTMLElement</code> or <code>RegExp</code> do),
+            so you can't always use (for example)
+            <br><code>IS(new Float32Array(1), Float32Array)</code>,
+            <br>...but you <i>can</i> use a string here:
+            <br><code>IS(new Float32Array(1), "Float32Array")</code>
+            <br>See also: <a target="_blank"
+              href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toStringTag"
+              >MDN documentation</a></div>
+          </div>`,
+    _ => div[type],
+    _ => Symbol.for(`is`)[type],
+    _ => Symbol.is[Symbol.is](Symbol /* known global constructor */),
     _ => new Intl.Collator()[type],
+    _ => new Intl.Collator()[is](`Intl.Collator`),
+    _ => new Intl.Collator()[is](Object),
     _ => new Float32Array(1)[type],
+    _ => new Float32Array(1)[is](TypedArray /* not a known global constructor */),
+    _ => new Float32Array(1)[is](Object),
+    _ => new Float32Array(1)[is](Array, "Float32Array"),
     _ => new Error(`error!`)[type],
     _ => new DataView(new ArrayBuffer(2))[type],
-    _ => function* () {
-      yield 'a';
-      yield 'b';
-      yield 'c';
-    }[type],
+    _ => function* () { yield 'a'; yield 'b'; yield 'c'; }[type],
     _ => new FinalizationRegistry(_ => {})[type],
-    _ => IteratorTrial,
+    _ => new FinalizationRegistry(_ => {})[is]("FinalizationRegistry"),
+    _ => new FinalizationRegistry(_ => {})[is](Function, "FinalizationRegistry"),
+    _ => new FinalizationRegistry(_ => {})[is](Function),
+    _ => new FinalizationRegistry(_ => {})[is](Object),
+    _ => Iterator[type],
+    _ => Iterator.from([1,2,3])[type],
+    _ => Iterator.from([1,2,3])[is](`Array Iterator`),
+    _ => Iterator.from([1,2,3])[is](Object),
     _ => new AggregateError(`aggregateError!`)[type],
-    _ => SharedArrayBufferTrial,
+    _ => new SharedArrayBuffer(16)?.[type],
+    _ => Intl[type],
+    _ => Intl[is](Object),
+    _ => Intl[is](`Intl`),
     _ => Intl.Collator[type],
+    _ => Intl.Collator[is](Function),
+    _ => JSON[type],
+    _ => JSON[is](Object),
+    _ => Math[type],
+    _ => new Promise((a, b) => {})[type],
+    _ => new Promise((a, b) => {})[is](Promise),
     _ => function* () {}[type],
+    _ => function* () {}[is](Function),
+    _ => function* () {}[is](`GeneratorFunction`),
   ]
 }
 
@@ -344,16 +363,17 @@ function wrap2Container() {
 
 function logExampleCB(example) {
   const fn = example.toString().trim();
-  const result = example();
-  return maybe({
-    trial: _ =>
-      fn.startsWith('t')
-        ? result && log(`!!${example()}`)
-        : log(toCode(String(fn).slice(4), example())),
-    whenError: err => {
-      log(`<pre>${err}</pre>`);
-      console.error(err);
-    } });
+  const whenError = err => {
+    log(`Tried: <code>${fn.slice(fn.indexOf(`>`)+1)}</code>,
+      <br>Failed with ${err.name}: "${err.message}".`);
+    return console.error(err);
+  };
+  const result = maybe({trial: example, whenError});
+  if (!isNothing(result)) {
+    return fn.startsWith('t')
+      ? result && log(`!!${example()}`)
+      : log(toCode(String(fn).slice(4), example()))
+  }
 }
 
 function printExamples() {

--- a/Demo/index.js
+++ b/Demo/index.js
@@ -29,7 +29,9 @@ function getHeader() {
   return t => `<p>${backLink}
     | <a target="_blank" href="https://www.npmjs.com/package/typeofanything">@NPM</a></p>
     <div class="normal"><h3>TypeofAnything: determine/check the type of nearly any (ECMAScript) thing</h3>
-      (including null/undefined/NaN/true/false etc.)</div>
+      (including null/undefined/NaN/true/false etc.)
+    </div>
+    <div class="normal noborder"><h3>Code used for examples</h3></div>
     <code class="block">
     // import & initialize
     import { 
@@ -80,7 +82,7 @@ function codeExamples() {
   
   return [
     getHeader(),
-    t => `<div class="normal"><b>The IS function</b></div>`,
+    t => `<div class="normal" id="IS" data-content-text="The IS function"><b>The IS function</b></div>`,
     _ => IS([]),
     _ => IS([], Array),
     _ => IS("nothing", Array, String),
@@ -92,7 +94,7 @@ function codeExamples() {
     _ => IS({} + [], String /* ES peculiarity */),
     _ => IS(true + false, Number /* ES peculiarity */),
 
-    t => `<div class="normal"><b>The Object symbolic extension</b></div>`,
+    t => `<div class="normal" id="symbolicExt" data-content-text="The Object symbolic extension"><b>The Object symbolic extension</b></div>`,
     _ => [][type],
     _ => [][is](Map),
     _ => ({})[is](Array),
@@ -108,7 +110,7 @@ function codeExamples() {
     _ => ({})[Symbol.is](Array),
     _ => [][Symbol.is](Object /* up the prototoype chain */),
 
-    t => `<div class="normal"><b>The <i>static</i> Object symbolic extension</b></div>`,
+    t => `<div class="normal" id="staticSymbol" data-content-text="The <i>static</i> Object symbolic extension"><b>The <i>static</i> Object symbolic extension</b></div>`,
     _ => Object[type](`Hello`),
     _ => Object[is]([], Map),
     _ => Object[is]([], Array),
@@ -117,7 +119,7 @@ function codeExamples() {
     _ => Object[is](not_a_nr, NaN, Number),
     _ => Object[is](`Hello world`, NaN, Number, String),
 
-    t => `<div class="normal"><b>The wrapper <code>$Wrap</code></b></div>`,
+    t => `<div class="normal" id="wrapper" data-content-text="The wrapper <code>$Wrap</code>"><b>The wrapper <code>$Wrap</code></b></div>`,
     _ => $Wrap([])[type],
     _ => $Wrap([]).type,
     _ => $Wrap([])[is](Map),
@@ -131,7 +133,7 @@ function codeExamples() {
     _ => null?.[type] ?? $Wrap(null).type,
     _ => undefined?.[is](undefined) ?? $Wrap(undefined).is(undefined),
 
-    t => `<div class="normal"><b>The <code>maybe</code> function</b></div>`,
+    t => `<div class="normal" id="maybe" data-content-text="The <code>maybe</code> function"><b>The <code>maybe</code> function</b></div>`,
     _ => maybe({trial() {return {};}})[is](Object),
     _ => maybe({trial: () => $Wrap(null)}).is(null),
     _ => maybe({trial: () => 1 === 2})[is](Boolean),
@@ -143,7 +145,7 @@ function codeExamples() {
     _ => maybe({trial: () => {throw new TypeError(`no!`);}, whenError(err) {return err.name; }}),
     _ => maybe({trial: () => {throw new TypeError(`no!`);}, whenError(err) {return err.name; }})[is](String),
 
-    t => `<div class="normal">
+    t => `<div class="normal" id="proxy" data-content-text="Proxy 'type'">
             <b>Proxy</b><br>
             A <code>Proxy</code> instance has no prototype,
             it is designed to be transparent to the proxied Object.
@@ -164,7 +166,6 @@ function codeExamples() {
     _ => proxyEx[is](Proxy),
     _ => proxyEx[is](String),
 
-    // TODO
     t => xProxy.native(),
     t => `<div class="normal">When we reset <code>Proxy</code>
           to its initial constructor (using <code>xProxy.native()</code>),
@@ -174,15 +175,17 @@ function codeExamples() {
     _ => new Proxy(new Date(), {})[type],
     _ => new Proxy(new Date(), {})[is](Date),
 
-    t => `<div class="normal"><b>Note</b>: <code>proxyEx</code> was assigned with the modified
+    t => `<div class="normal">
+          <b>Note</b>: <code>proxyEx</code> was assigned with the modified
            <code>Proxy</code> constructor, so:</div>`,
     _ => proxyEx[type],
     _ => proxyEx[is](Proxy),
     _ => proxyEx[is](String),
 
-    t => `<div class="normal"><b>null, undefined, true, false</b>
-          <br><b>Note</b>: <code>null</code> and <code>undefined</code>
-          must always be wrapped. </div>`,
+    t => `<div class="normal" id="nulletc" data-content-text="null, undefined, true, false">
+            <b>null, undefined, true, false</b>
+            <br><b>Note</b>: <code>null</code> and <code>undefined</code>
+            must always be wrapped. </div>`,
     _ => maybe({trial: () => nil[type], whenError: () => `WRAPPED ${$Wrap(nil).type}`}),
     _ => maybe({trial: () => undef[type], whenError: () => `WRAPPED ${$Wrap(undef).type}`}),
     _ => nil?.[type] ?? $Wrap(nil)[type],
@@ -198,7 +201,7 @@ function codeExamples() {
     _ => undef?.[is](undefined) ?? $Wrap(undef)[is](undefined),
     _ => undef?.[is](null, NaN) ?? $Wrap(undef)[is](null, NaN),
 
-    t => `<div class="normal"><b>'Nothingness'</b> (<code>isNothing</code>)<br>
+    t => `<div class="normal" id="nothing" data-content-text="'Nothingness'</b> (<code>isNothing</code>)"><b>'Nothingness'</b> (<code>isNothing</code>)<br>
           <code>isNothing</code> is a special
           function imported from the module.
           <br>It determines if a
@@ -222,7 +225,7 @@ function codeExamples() {
     _ => isNothing(new Date()),
     _ => isNothing(new Date(), true),
 
-    t => `<div class="normal"><b>0 (zero)</b></div>`,
+    t => `<div class="normal" id="zero" data-content-text="0 (zero)"><b>0 (zero)</b></div>`,
     _ => zero[type],
     _ => zero[is](Boolean /* should be false */),
     _ => zero[is](Number /* literal is Number */),
@@ -230,7 +233,7 @@ function codeExamples() {
     _ => new Number(zero)[is](Number),
     _ => new Number(zero)[is](Object /*<br>&nbsp;&nbsp;Up the prototype chain, Number instance is also Object */),
 
-    t => `<div class="normal"><b>NaN</b></div>`,
+    t => `<div class="normal" id="nan" data-content-text="NaN"><b>NaN</b></div>`,
     _ => typeof not_a_nr,
     _ => not_a_nr[is](Number /* by design we DON'T consider NaN to be Number */),
     _ => not_a_nr[type],
@@ -241,7 +244,7 @@ function codeExamples() {
     _ => new Number(not_a_nr)[type],
     _ => new Number(not_a_nr)[is](NaN),
 
-    t => `<div class="normal"><b>Special cases</b>
+    t => `<div class="normal" id="specials" data-content-text="Special cases"><b>Special cases</b>
             (<code>IS(input, {isTypes: [...types], notTypes: [...types]|defaultValue: any})</code>)
             <div>When the second parameter (or the first, using the Object symbol extension or <code>$Wrap</code>)
               is an Object with key [<code>isTypes</code>] and one of the keys [<code>defaultValue</code>]
@@ -275,23 +278,8 @@ function codeExamples() {
     _ => new Proxy(new Date(), {})[type],
     _ => new Proxy(new Date(), {})[is]({isTypes: Proxy, notTypes: Date}),
     _ => new Proxy(new Date(), {})[is]({isTypes: Date, notTypes: Proxy}),
-
-    t => `<div class="normal"><b>More examples</b></div>`,
-    _ => /[a-z]/[type],
-    _ => /[a-z]/[is](RegExp),
-    _ => /[a-z]/[is](Array),
-    _ => ``[type],
-    _ => new SomeCTOR("yada")[type],
-    _ => new SomeCTOR("yada")[is](SomeCTOR),
-    _ => new SomeCTOR("yada")[is](Object /* up the prototype chain */),
-    _ => Symbol(`me`)[is](Symbol),
-    _ => div[is](Node),
-    _ => div[is](HTMLElement),
-    _ => div[is](HTMLDivElement),
-    _ => div[is](HTMLUListElement),
-    _ => div[is](HTMLUListElement, HTMLAreaElement, Node),
     
-    t => `<div class="normal"><b>toStringTag</b>:
+    t => `<div class="normal" id="tostringtag" data-content-text="toStringTag"><b>toStringTag</b>:
             use <code>Symbol.toStringTag</code> for reporting/checking 'types'.
           <div>A number of ES20xx Objects contain the 'well known Symbol'
             <code>Symbol.toStringTag</code> in their prototype. Such objects
@@ -345,6 +333,21 @@ function codeExamples() {
     _ => function* () {}[type],
     _ => function* () {}[is](Function),
     _ => function* () {}[is](`GeneratorFunction`),
+    
+    t => `<div class="normal" id="more" data-content-text="More examples"><b>More examples</b></div>`,
+    _ => /[a-z]/[type],
+    _ => /[a-z]/[is](RegExp),
+    _ => /[a-z]/[is](Array),
+    _ => ``[type],
+    _ => new SomeCTOR("yada")[type],
+    _ => new SomeCTOR("yada")[is](SomeCTOR),
+    _ => new SomeCTOR("yada")[is](Object /* up the prototype chain */),
+    _ => Symbol(`me`)[is](Symbol),
+    _ => div[is](Node),
+    _ => div[is](HTMLElement),
+    _ => div[is](HTMLDivElement),
+    _ => div[is](HTMLUListElement),
+    _ => div[is](HTMLUListElement, HTMLAreaElement, Node),
   ]
 }
 
@@ -357,8 +360,21 @@ function toCode(str, res) {
       : res}`;
 }
 
-function wrap2Container() {
-  $(`<div class="container">`).append($(`ul#log2screen`));
+function addContentIndex() {
+  const contentElements = document.querySelectorAll(`[data-content-text]`);
+  const ul = Object.assign(document.createElement("ul"), {classList: `content`});
+  ul.insertAdjacentHTML(`beforeend`, `<li class="head"><h3>Content</h3></li>`);
+  contentElements.forEach(element => {
+    ul.insertAdjacentHTML(`beforeend`,
+      `<li><a href="#${element.id}">${element.dataset.contentText}</a></li>`);
+    element.querySelector(`b`).title = "Content ↑";
+  });
+  const normalDiv = Object.assign(document.createElement("div"),
+    {classList: `normal top noborder`});
+  normalDiv.append(ul);
+  document.querySelector(`#log2screen li:first-child .normal`)
+    .insertAdjacentElement(`afterend`, normalDiv);
+  
 }
 
 function logExampleCB(example) {
@@ -377,8 +393,15 @@ function logExampleCB(example) {
 }
 
 function printExamples() {
+  document.addEventListener(`click`, handle);
   codeExamples().forEach(logExampleCB);
+  addContentIndex();
 }
+
+function handle(evt) {
+  if (evt.target.closest(`[data-content-text]`)) {
+    return document.querySelector(`#log2screen li:first-child`).scrollIntoView();
+  }}
 
 function logFactory(formatJSON = true) {
   const logContainer = document.querySelector(`#log2screen`);

--- a/Demo/style.css
+++ b/Demo/style.css
@@ -81,7 +81,7 @@ body {
         }
 
         &:last-child {
-          padding-bottom: 2rem;
+          padding-bottom: 100rem;
         }
 
         &.head {
@@ -105,6 +105,29 @@ body {
 
             b {
               color: rgb(179, 21, 55);
+            }
+
+            b:first-child {
+              cursor: pointer;
+              &:hover {
+                background-color: lightgoldenrodyellow;
+              }
+            }
+          }
+
+          .normal.noborder {
+            border-bottom: none;
+          }
+
+          .normal.top {
+            margin-left: -0.5rem;
+            padding-bottom: 1.5rem;
+            a {
+              font-weight: normal;
+              &:hover {
+                text-decoration: none;
+                border-bottom: 1px dotted #777;
+              }
             }
           }
         }

--- a/Demo/style.css
+++ b/Demo/style.css
@@ -1,151 +1,117 @@
 body {
   font: 14px / 17px system-ui, sans-serif;
   margin: 1rem;
-}
 
-code {
-  color: green;
-  background-color: rgb(238, 238, 238);
-  padding: 2px;
-  font-family: monospace;
-}
+  h3 {
+    margin: 1rem 0 0.2rem 0;
+  }
 
-code.codeblock {
-  display: block;
-  padding: 6px;
-  border: 1px solid rgb(153, 153, 153);
-  margin: 0.5rem 0px;
-  background-color: rgb(238, 238, 238);
-  white-space: pre-wrap;
-}
+  a {
+    text-decoration: none;
+    font-weight: bold;
+  }
 
-h3 {
-  margin-top: 1.5rem;
-}
+  a:hover {
+    text-decoration: underline;
+  }
 
-.thickBorder {
-  border: 5px solid green;
-  padding: 0.5rem;
-  display: inline-block;
-}
+  a[target]::before, a.internalLink::before, a.externalLink::before {
+    color: rgba(0, 0, 238, 0.7);
+    font-size: 1.1rem;
+    padding-right: 2px;
+    vertical-align: baseline;
+  }
 
-a.ExternalLink {
-  text-decoration: none;
-  color: rgb(0, 0, 238);
-  background-color: rgb(238, 238, 238);
-  padding: 3px;
-  font-weight: bold;
-}
+  a[target="_blank"]::before, a.externalLink::before {
+    content: "↗";
+  }
 
-.cmmt {
-  color: rgb(136, 136, 136);
-}
+  a[data-top]::before, a.internalLink::before, a[target="_top"]::before {
+    content: "↺";
+  }
 
-.hidden {
-  display: none;
-}
+  .hidden {
+    display: none;
+  }
 
-.attention {
-  color: red;
-  font-size: 1.2em;
-  font-weight: bold;
-}
+  .err {
+    font-style: italic;
+    color: red;
+  }
 
-#log2screen li {
-  list-style: "✓";
-  padding-left: 6px;
-  margin: 0.5rem 0px 0px -1.2rem;
-  font-family: monospace;
-}
+  .container {
+    inset: 0;
+    position: absolute;
 
-#log2screen li.head {
-  list-style-type: none;
-  font-weight: bold;
-  margin-top: 0.8rem;
-  margin-bottom: -0.2rem;
-  font-family: revert;
-}
-
-.err {
-  font-style: italic;
-  color: red;
-}
-
-a {
-  text-decoration: none;
-  font-weight: bold;
-}
-
-a:hover {
-  text-decoration: underline;
-}
-
-a[target]::before, a.internalLink::before, a.externalLink::before {
-  color: rgba(0, 0, 238, 0.7);
-  font-size: 1.1rem;
-  padding-right: 2px;
-  vertical-align: baseline;
-}
-
-a[target="_blank"]::before, a.externalLink::before {
-  content: "↗";
-}
-
-a[data-top]::before, a.internalLink::before, a[target="_top"]::before {
-  content: "↺";
-}
-
-.container {
-  inset: 0px;
-  position: absolute;
-
-  & #log2screen {
-    position: relative;
-    margin: 0px auto;
-    max-width: 800px;
-
-    & code {
-      padding: 0px 3px !important;
+    code:not(.language-javascript) {
+      background-color: rgb(227, 230, 232);
+      color: rgb(12, 13, 14);
+      padding: 2px 4px;
+      display: inline;
+      border-radius: 4px;
+      margin: 1px 0;
     }
 
-    & li {
-      margin: 0.5rem 0.6rem 0px -0.6rem;
+    #log2screen {
+      position: relative;
+      margin: 0 auto;
+      max-width: 800px;
 
-      & code:not(.language-javascript) {
-        background-color: rgb(227, 230, 232);
-        color: rgb(12, 13, 14);
-        padding: 2px 4px;
-        display: inline;
-        border-radius: 4px;
-        margin: 1px 0px;
-      }
+      li {
+        margin-top: 0.1rem;
+        font: revert;
+        font-size: 1.1em;
+        line-height: 1.4rem;
+        padding: 0 5px;
+        margin-left: -1.2rem;
+        list-style: "✓";
 
-      &:last-child {
-        padding-bottom: 2rem;
-      }
+        ul {
+          margin: 0;
+          li {
+            margin-top: 0.1rem;
+            font: revert;
+            padding: 0px 5px;
+            margin-left: -1.2rem;
 
-      &.head .normal {
-        font-weight: normal;
-        line-height: 20px;
-        margin: 12px 0px 6px;
-        color: rgb(69, 104, 161);
-
-        & b {
-          color: rgb(179, 21, 55);
+            &:last-child {
+              padding-bottom: revert;
+            }
+          }
         }
 
-        & li {
-          margin-top: 0.1rem;
-          font: revert;
-          padding: 0px 5px;
-          margin-left: -1.2rem;
+        &:last-child {
+          padding-bottom: 2rem;
         }
-      }
 
-      &.head code.language-javascript {
-        background-color: revert;
-        color: revert;
+        &.head {
+          list-style-type: none;
+          font-weight: bold;
+          margin: 0.8rem 0 0 -2rem;
+          font-family: revert;
+
+          code.language-javascript {
+            background-color: revert;
+            color: revert;
+          }
+
+          .normal {
+            font-weight: normal;
+            line-height: 20px;
+            margin: 12px 0 6px;
+            color: rgb(69, 104, 161);
+            padding-bottom: 0.2em;
+            border-bottom: 1px dotted #777;
+
+            b {
+              color: rgb(179, 21, 55);
+            }
+          }
+        }
       }
     }
   }
 }
+
+
+

--- a/typeofany.module.js
+++ b/typeofany.module.js
@@ -7,9 +7,10 @@ function TOAFactory() {
   Symbol.type = Symbol.for(`toa.type`);
   Symbol.any = Symbol.for(`toa.any`);
   addSymbols2Anything();
+  const maybe = maybeFactory();
   const [$Wrap, xProxy] = [WrapAnyFactory(), setProxyFactory()];
   xProxy.custom();
-  return { IS, maybe: maybeFactory(), $Wrap, isNothing, xProxy };
+  return { IS, maybe, $Wrap, isNothing, xProxy };
   
   function IS(anything, ...shouldBe) {
     if (shouldBe.length && shouldBe[0]?.isTypes) {
@@ -117,12 +118,12 @@ function TOAFactory() {
   }
   
   function setProxyFactory() {
-    const nativeProxy = window.Proxy;
+    const nativeProxy = Proxy;
     return {
-      native() { window.Proxy = nativeProxy; },
+      native() { Proxy = nativeProxy; },
       custom() {
         // adaptation of https://stackoverflow.com/a/53463589
-        window.Proxy = new nativeProxy(nativeProxy, {
+        Proxy = new nativeProxy(nativeProxy, {
           construct(target, args) {
             const proxy = new target(...args);
             proxy[Symbol.proxy] = `Proxy (${determineType(args[0])})`;


### PR DESCRIPTION
1.  A number of ES20xx Objects contain the 'well known Symbol' `Symbol.toStringTag`  in their prototype. Such objects  use that Symbol for their string representation (`toString`).  
  Such 'types' are *not always available* as known constructors in   the (global) namespace (like for example `HTMLElement` or 
  `RegExp`  are),  so one can't always use (for example)  `IS(new Float32Array(1), Float32Array)`).
2. For the `Proxy` type check, the global `window` `namespace disables the library for use in NodeJS.

## added functionality
- When `toStringTag` is available `IS(input)` or  `[type]` reports  that as the 'type' of the input between square brackets (e.g. `[object Array Iterator]`).
- One can check non-available global constructors using their *string representation*, e.g. `IS(new Float32Array(1), "Float32Array")`
- `window` is removed from the rewritten `Proxy`, which enables its use in NodeJS.

See also [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toStringTag)